### PR TITLE
fix: add generic to actionChannel

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -359,6 +359,10 @@ export function select<Fn extends (state: any, ...args: any[]) => any>(
   ...args: Tail<Parameters<Fn>>
 ): SagaGenerator<ReturnType<Fn>, SelectEffect>;
 
+export function actionChannel<A extends Action>(
+  pattern?: ActionPattern<A>,
+  buffer?: Buffer<Action>,
+): SagaGenerator<Channel<A>, ActionChannelEffect>;
 export function actionChannel(
   pattern: ActionPattern,
   buffer?: Buffer<Action>,


### PR DESCRIPTION
Currently, `const channel = yield* actionChannel(createAddTaskAction)` returns a generic action but not the one returned from the action creator. This change returns a channel that is specific to the passed action creator.