### PR TITLE
Improves args type inference for call, apply, fork & spawn

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -184,60 +184,75 @@ export function putResolve<A extends Action>(
   action: A,
 ): SagaGenerator<A, PutEffect<A>>;
 
-export function call<Fn extends (...args: any[]) => any>(
+export function call<Args extends any[], Fn extends (...args: Args) => any>(
   fn: Fn,
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<SagaReturnType<Fn>, CallEffect<SagaReturnType<Fn>>>;
 export function call<
+  Args extends any[],
   Ctx extends {
-    [P in Name]: (this: Ctx, ...args: any[]) => any;
+    [P in Name]: (this: Ctx, ...args: Args) => any;
   },
   Name extends string,
 >(
   ctxAndFnName: [Ctx, Name],
-  ...args: Parameters<Ctx[Name]>
+  ...args: Args
 ): SagaGenerator<
   SagaReturnType<Ctx[Name]>,
   CallEffect<SagaReturnType<Ctx[Name]>>
 >;
 export function call<
+  Args extends any[],
   Ctx extends {
-    [P in Name]: (this: Ctx, ...args: any[]) => any;
+    [P in Name]: (this: Ctx, ...args: Args) => any;
   },
   Name extends string,
 >(
   ctxAndFnName: { context: Ctx; fn: Name },
-  ...args: Parameters<Ctx[Name]>
+  ...args: Args
 ): SagaGenerator<
   SagaReturnType<Ctx[Name]>,
   CallEffect<SagaReturnType<Ctx[Name]>>
 >;
-export function call<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+export function call<
+  Ctx,
+  Args extends any[],
+  Fn extends (this: Ctx, ...args: Args) => any,
+>(
   ctxAndFn: [Ctx, Fn],
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<SagaReturnType<Fn>, CallEffect<SagaReturnType<Fn>>>;
-export function call<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+export function call<
+  Ctx,
+  Args extends any[],
+  Fn extends (this: Ctx, ...args: Args) => any,
+>(
   ctxAndFn: { context: Ctx; fn: Fn },
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<SagaReturnType<Fn>, CallEffect<SagaReturnType<Fn>>>;
 
 export function apply<
+  Args extends any[],
   Ctx extends {
-    [P in Name]: (this: Ctx, ...args: any[]) => any;
+    [P in Name]: (this: Ctx, ...args: Args) => any;
   },
   Name extends string,
 >(
   ctx: Ctx,
   fnName: Name,
-  args: Parameters<Ctx[Name]>,
+  args: Args,
 ): SagaGenerator<
   SagaReturnType<Ctx[Name]>,
   CallEffect<SagaReturnType<Ctx[Name]>>
 >;
-export function apply<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+export function apply<
+  Ctx,
+  Args extends any[],
+  Fn extends (this: Ctx, ...args: Args) => any,
+>(
   ctx: Ctx,
   fn: Fn,
-  args: Parameters<Fn>,
+  args: Args,
 ): SagaGenerator<SagaReturnType<Fn>, CallEffect<SagaReturnType<Fn>>>;
 
 export function cps<Fn extends (cb: CpsCallback<any>) => any>(
@@ -280,93 +295,113 @@ interface FixedTask<A> extends Task {
   result: <T = A>() => T | undefined;
   toPromise: <T = A>() => Promise<T>;
 }
-export function fork<Fn extends (...args: any[]) => any>(
+export function fork<Args extends any[], Fn extends (...args: Args) => any>(
   fn: Fn,
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Fn>>,
   ForkEffect<SagaReturnType<Fn>>
 >;
 export function fork<
+  Args extends any[],
   Ctx extends {
-    [P in Name]: (this: Ctx, ...args: any[]) => any;
+    [P in Name]: (this: Ctx, ...args: Args) => any;
   },
   Name extends string,
 >(
   ctxAndFnName: [Ctx, Name],
-  ...args: Parameters<Ctx[Name]>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Ctx[Name]>>,
   ForkEffect<SagaReturnType<Ctx[Name]>>
 >;
 export function fork<
+  Args extends any[],
   Ctx extends {
-    [P in Name]: (this: Ctx, ...args: any[]) => any;
+    [P in Name]: (this: Ctx, ...args: Args) => any;
   },
   Name extends string,
 >(
   ctxAndFnName: { context: Ctx; fn: Name },
-  ...args: Parameters<Ctx[Name]>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Ctx[Name]>>,
   ForkEffect<SagaReturnType<Ctx[Name]>>
 >;
-export function fork<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+export function fork<
+  Ctx,
+  Args extends any[],
+  Fn extends (this: Ctx, ...args: Args) => any,
+>(
   ctxAndFn: [Ctx, Fn],
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Fn>>,
   ForkEffect<SagaReturnType<Fn>>
 >;
-export function fork<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+export function fork<
+  Ctx,
+  Args extends any[],
+  Fn extends (this: Ctx, ...args: Args) => any,
+>(
   ctxAndFn: { context: Ctx; fn: Fn },
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Fn>>,
   ForkEffect<SagaReturnType<Fn>>
 >;
 
-export function spawn<Fn extends (...args: any[]) => any>(
+export function spawn<Args extends any[], Fn extends (...args: Args) => any>(
   fn: Fn,
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Fn>>,
   ForkEffect<SagaReturnType<Fn>>
 >;
 export function spawn<
+  Args extends any[],
   Ctx extends {
-    [P in Name]: (this: Ctx, ...args: any[]) => any;
+    [P in Name]: (this: Ctx, ...args: Args) => any;
   },
   Name extends string,
 >(
   ctxAndFnName: [Ctx, Name],
-  ...args: Parameters<Ctx[Name]>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Ctx[Name]>>,
   ForkEffect<SagaReturnType<Ctx[Name]>>
 >;
 export function spawn<
+  Args extends any[],
   Ctx extends {
-    [P in Name]: (this: Ctx, ...args: any[]) => any;
+    [P in Name]: (this: Ctx, ...args: Args) => any;
   },
   Name extends string,
 >(
   ctxAndFnName: { context: Ctx; fn: Name },
-  ...args: Parameters<Ctx[Name]>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Ctx[Name]>>,
   ForkEffect<SagaReturnType<Ctx[Name]>>
 >;
-export function spawn<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+export function spawn<
+  Ctx,
+  Args extends any[],
+  Fn extends (this: Ctx, ...args: Args) => any,
+>(
   ctxAndFn: [Ctx, Fn],
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Fn>>,
   ForkEffect<SagaReturnType<Fn>>
 >;
-export function spawn<Ctx, Fn extends (this: Ctx, ...args: any[]) => any>(
+export function spawn<
+  Ctx,
+  Args extends any[],
+  Fn extends (this: Ctx, ...args: Args) => any,
+>(
   ctxAndFn: { context: Ctx; fn: Fn },
-  ...args: Parameters<Fn>
+  ...args: Args
 ): SagaGenerator<
   FixedTask<SagaReturnType<Fn>>,
   ForkEffect<SagaReturnType<Fn>>

--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -213,4 +213,42 @@ function* mySaga(): Effects.SagaGenerator<void> {
       return "hello";
     }),
   });
+
+  function outer<T>(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    emit: (item: T) => T,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handler: (item: T) => T,
+  ) {}
+  const obj = { outer };
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function makeEmit<T>(x: T, y: T) {
+    return (item: T) => item;
+  }
+
+  function handler(item: number) {
+    return item;
+  }
+  const emitter = makeEmit<number>(2, 3);
+
+  yield* Effects.call(outer, emitter, handler);
+  yield* Effects.call([obj, obj.outer], emitter, handler);
+  yield* Effects.call([obj, "outer"], emitter, handler);
+  yield* Effects.call({ context: obj, fn: obj.outer }, emitter, handler);
+  yield* Effects.call({ context: obj, fn: "outer" }, emitter, handler);
+
+  yield* Effects.apply(obj, outer, [emitter, handler]);
+  yield* Effects.apply(obj, "outer", [emitter, handler]);
+
+  yield* Effects.fork(outer, emitter, handler);
+  yield* Effects.fork([obj, obj.outer], emitter, handler);
+  yield* Effects.fork([obj, "outer"], emitter, handler);
+  yield* Effects.fork({ context: obj, fn: obj.outer }, emitter, handler);
+  yield* Effects.fork({ context: obj, fn: "outer" }, emitter, handler);
+
+  yield* Effects.spawn(outer, emitter, handler);
+  yield* Effects.spawn([obj, obj.outer], emitter, handler);
+  yield* Effects.spawn([obj, "outer"], emitter, handler);
+  yield* Effects.spawn({ context: obj, fn: obj.outer }, emitter, handler);
+  yield* Effects.spawn({ context: obj, fn: "outer" }, emitter, handler);
 }


### PR DESCRIPTION
Small tweak to the setup of the generic types for `call`, `apply`, `fork`, and `spawn` to better infer the type for the given function's arguments.