### PR TITLE
Failing test for when a generator with a race is called

### DIFF
--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -214,6 +214,12 @@ function* mySaga(): Effects.SagaGenerator<void> {
     }),
   });
 
+  // $ExpectType boolean
+  yield* Effects.call(function* () {
+    yield* Effects.race({ timeout: Effects.delay(1) });
+    return true;
+  });
+
   function outer<T>(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     emit: (item: T) => T,


### PR DESCRIPTION
I think the inferred return type is incorrect when you call a generator that in turn does a race. The test in this draft PR is the minimal example I could come up with. I don't know how to attempt to fix this. :-)