### PR TITLE
Add tests showing code that fails in 1.5 that worked in 1.4

### DIFF
--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -251,4 +251,21 @@ function* mySaga(): Effects.SagaGenerator<void> {
   yield* Effects.spawn([obj, "outer"], emitter, handler);
   yield* Effects.spawn({ context: obj, fn: obj.outer }, emitter, handler);
   yield* Effects.spawn({ context: obj, fn: "outer" }, emitter, handler);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function handleArgumentThatIsPartOfUnion(requestId: 27 | 28) {
+    return 22;
+  }
+  // $ExpectType number
+  yield* Effects.call(handleArgumentThatIsPartOfUnion, 27);
+
+  type FetchOptions = {
+    readonly method?: "GET" | "POST";
+  };
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function* ourFetch(options: FetchOptions) {}
+  // Fails in 1.5 as argument is widened to string it seems (works in 1.4)
+  yield* Effects.call(ourFetch, { method: "POST" });
+  // Works (in 1.5 and 1.4, but this workaround is not possible for the numeric case above)
+  yield* Effects.call(ourFetch, { method: "POST" as const });
 }


### PR DESCRIPTION
It seems the type inferencing changes on arguments in 1.5 breaks a few patterns in our code.

Added two examples with `call` where the argument passed is part of a union of values, this now fails as type errors. For strings I'm able to work around it with using `as const`, but for numbers I do not think that is possible.

I had a look at the code changes in #654 but I'm not sure if there is any easy way to fix this?