### PR TITLE
Add a type for take patterns

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,6 +50,8 @@ export type SagaGenerator<RT, E extends Effect = Effect<any, any>> = Generator<
   RT
 >;
 
+type ExtractAction<T> = T extends ActionPattern<infer A> ? A : never;
+
 export function take<A extends Action>(
   pattern?: ActionPattern<A>,
 ): SagaGenerator<A, TakeEffect>;
@@ -58,6 +60,9 @@ export function take<T>(
   multicastPattern?: Pattern<T>,
 ): SagaGenerator<T, ChannelTakeEffect<T>>;
 export function take(pattern?: ActionPattern): SagaGenerator<any, TakeEffect>;
+export function take<T extends ActionPattern[]>(
+  patterns: T,
+): SagaGenerator<ExtractAction<T>, TakeEffect>;
 
 export function takeMaybe<A extends Action>(
   pattern?: ActionPattern<A>,

--- a/types/index.test.ts
+++ b/types/index.test.ts
@@ -13,6 +13,10 @@ function* mySaga(): Effects.SagaGenerator<void> {
   yield* Effects.take("FOO"); // $ExpectType Action<any>
   type FooAction = { readonly type: "FOO" };
   yield* Effects.take<FooAction>("FOO"); // $ExpectType FooAction
+  const fooActionCreator = (payload: number) => ({ type: 'foo' as const, payload });
+  const barActionCreator = (payload: string[]) => ({ type: 'bar' as const, payload });
+  // $ExpectType { type: "foo"; payload: number; } | { type: "bar"; payload: string[]; }
+  yield* Effects.take([fooActionCreator, barActionCreator]);
   yield* Effects.takeMaybe("FOO"); // $ExpectType Action<any>
   yield* Effects.takeMaybe<FooAction>("FOO"); // $ExpectType FooAction
 


### PR DESCRIPTION
According to redux saga docs, [take effect can receive patterns(array of pattern)](https://redux-saga.js.org/docs/api#takepattern).

But current result of the effect is `any`.

```js
// action is any
// this should be FooAction | BarAction
const action = yield* take([foo, bar]);
```

So I added a type overloading to make it work properly.