### PR TITLE
chore: add package homepage metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "type": "git",
     "url": "https://github.com/agiledigital/typed-redux-saga.git"
   },
+  "homepage": "https://github.com/agiledigital/typed-redux-saga#readme",
   "bugs": {
     "url": "https://github.com/agiledigital/typed-redux-saga/issues"
   },


### PR DESCRIPTION
## Summary
- add the package `homepage` field pointing to the repository README
- leave runtime code, dependencies, package version, and package contents unchanged

## Verification
- node package metadata assertion
- npm pack --dry-run --ignore-scripts --json
- git diff --check

Note: `npm test -- --runInBand` could not run in this checkout because dependencies are not installed (`jest: command not found`).